### PR TITLE
update CLAUDE.md for current news lib structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,54 +4,73 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-Scouting411 (scouting411.org) is an Astro + React site that aggregates official Scouting America news and resources. It has two main content systems: a **news aggregator** (fetches/caches posts from external Scouting-related feeds) and a **resources directory** (a curated, hand-maintained list of official Scouting America links).
+Scouting411 (scouting411.org) is an Astro + React site that aggregates official Scouting America news and resources. Two content systems: a **news aggregator** (cron-refreshed cache of external Scouting feeds, browsable/filterable) and a **resources directory** (a hand-maintained list of official Scouting America links).
 
 ## Commands
 
-Package manager is pnpm (enforced via `preinstall`; do not use npm/yarn).
+Package manager is pnpm (`packageManager` pinned; Node >= 22.13.0 enforced via `engineStrict`).
 
-- `pnpm dev` — start the Astro dev server
-- `pnpm build` — production build
-- `pnpm check` — runs the full CI suite locally: `astro check` (typecheck) + `format` (prettier write) + `lint` (eslint) + `knip` (unused code) — run this before considering a change done
-- `pnpm format` / `pnpm format:check` — prettier write/check
-- `pnpm lint` — eslint on `src/**/*`
-- `pnpm knip` — finds unused files/exports/deps
-- `pnpm validateResourceLinks` — runs `scripts/validateResourceLinks.ts`, which checks every URL in the resources data actually resolves; also run in CI
-- `pnpm astro check` — Astro/TypeScript typechecking alone
+- `pnpm dev` — Astro dev server
+- `pnpm build` / `pnpm preview`
+- `pnpm check` — the local CI suite: `astro check` (typecheck) + `format` (prettier write) + `lint` + `knip`. Run before considering a change done.
+- `pnpm format:check` / `pnpm lint` / `pnpm knip` — individual checks
+- `pnpm validateResourceLinks` — hits every URL in `src/lib/resources/config.ts` to confirm it resolves. Run after touching resources; also runs in CI.
 
-There is no unit test runner in this repo (no test script/framework configured). CI (`.github/workflows/check.yaml`) runs prettier check, `astro check`, eslint, `validateResourceLinks`, and knip on every PR.
+There is no unit test framework in this repo. CI (`.github/workflows/check.yaml`, on PRs) runs prettier check, `astro check`, eslint, `validateResourceLinks`, and knip.
+
+`knip --treat-config-hints-as-errors` means unused exports/files/deps fail the build. Don't leave dead exports behind after a refactor.
+
+The `bruno/` directory holds a [Bruno](https://usebruno.com) collection for hitting the posts API by hand.
 
 ## Architecture
 
-### News aggregator (`src/lib/news/`)
+### News: ingest vs. query
 
-- **`config.ts`** — the single source of truth for all news feeds (`feedConfigs`). Each entry defines `name`, `slug`, `description`, `homepageUrl`, and an `adapter`. Many entries are commented out with `todo` notes explaining why a source is currently broken/disabled — check here before assuming a feed exists or works.
-- **`fetching/adapters/`** — one adapter per upstream source type: `rss.ts` (generic RSS/Atom via `feedsmith`), `wordpress.ts` (WordPress REST API), `tta.ts` (bespoke Trail to Adventure adapter, currently unused/excluded from knip). Adapters implement `FeedAdapter` (`fetching/types.ts`) and expose `.execute()` returning normalized `PostData[]`.
-- **`fetching/cache.ts`** — reads/writes each feed's fetched posts to Upstash Redis under key `posts:{slug}`. Feeds are never fetched live on request; only the cron job refreshes the cache.
-- **`fetching/update.ts`** — `updateAllFeeds()` calls every adapter and writes results to the cache. Triggered by `src/pages/api/updateAllFeeds.ts`, which is invoked by a Vercel cron job (`vercel.json`, daily at midnight) and secured by the `CRON_SECRET` env var.
-- **`feeds/feed.ts` / `feeds/feedManager.ts`** — `Feed` wraps a `FeedConfig` and reads its cached posts; `FeedManager` is the static registry over all feeds (`FeedManager.feeds`, `getFeedBySlug`, `getAllPosts()` merges+sorts posts across all feeds by date).
-- **`posts/post.ts`** — post domain model built from cached `PostData`.
-- **`query/`** — filtering (`filter.ts`), sorting (`sort.ts`), and query-param parsing (`queryParams.ts`, uses `qs`) for the news browse UI, exposed via `query/index.ts`.
-- Feed pages: `src/pages/feeds/[slug]/rss.ts` and `atom.ts` re-publish a single source's cached posts as RSS/Atom; `src/pages/feeds/all/opml.ts` emits an OPML list of all feeds.
+The news system is deliberately split into two halves that meet only at the Redis cache. Keep that boundary — `context/news-feed-rearchitecture.md` records the design reasoning behind it.
 
-### Resources directory (`src/lib/resources/`)
+**Write side (cron only):**
 
-- **`data.ts`** — hand-maintained array of `Resource` objects (see `types.ts`): each has `url`, `title`, `description`, and `tags` (`resourceType` + `topic`, drawn from `tags.ts`).
-- Inclusion criteria for resources are documented in `README.md` — official Scouting America national-level publications only, not council/district/unit/third-party, not part of a series, not superseded, not a single document/form. New resources are requested via GitHub issues (see `.github/ISSUE_TEMPLATE/`).
-- `scripts/validateResourceLinks.ts` validates every resource URL resolves; run this after adding/editing resources.
+- `src/lib/news/feeds/config.ts` — single source of truth for every feed. Each entry: `name`, `slug`, `description`, `homepageUrl`, `adapter`, `defaultVisible`. Many entries are commented out with `todo` notes explaining why the source is broken or unavailable — read here before assuming a feed exists. The exported array's literal type drives `FeedSlug` (a `z.enum` over the slugs), so adding a feed propagates types everywhere.
+- `src/lib/news/ingest/adapters/` — one adapter per upstream type: `rss.ts` (generic RSS/Atom via `feedsmith`), `wordpress.ts` (WordPress REST API), `tta.ts` (bespoke Trail to Adventure). Each implements `FeedAdapter` (`ingest/types.ts`) with `.execute(): Promise<PostData[]>`.
+- `src/lib/news/posts/update.ts` — `updateAllFeeds()` runs every adapter concurrently, isolating failures per feed so one bad source doesn't abort the run. A feed that returns zero posts is treated as a failure and its existing cache is kept.
+- `src/pages/api/updateAllFeeds.ts` — the only caller; a Vercel cron job (`vercel.json`, daily at midnight) guarded by a `Bearer ${CRON_SECRET}` auth header.
 
-### Frontend
+**Read side (every request):**
 
-- Astro pages in `src/pages/`; interactive UI is React islands under `src/components/react/` and `src/components/layout/` (e.g. `cardList.tsx`, `post.tsx`, `resource.tsx`, sidebar nav components).
-- `src/components/ui/` holds shadcn/ui components (config in `components.json`, style `base-luma`, icon library `lucide`). Add new shadcn components via the `shadcn` CLI rather than hand-writing them, so they stay consistent with the configured style/aliases.
-- State: `nanostores` (`src/stores/postsQuery.ts`) for the news browse query state, persisted via `@nanostores/persistent`.
-- Styling: Tailwind CSS v4 via `@tailwindcss/vite` (no separate tailwind config file — see `global.css` and `components.json`).
-- Path alias `@/*` maps to `src/*` (see `tsconfig.json`).
+- `src/lib/news/posts/cache.ts` — Redis JSON get/set at key `posts:{slug}`. Feeds are **never** fetched live on a page request.
+- `src/lib/news/posts/fetch.ts` — `getMultipleFeedsPosts(slugs)` does one Redis read per selected feed and hydrates `PostData` into `Post` (`posts/post.ts`) with its `Feed` attached. There's a `todo` to make these internal — prefer routing new post access through the query layer.
+- `src/lib/news/query/` — `query.ts`'s `queryPosts(opts)` is the entry point: fetch selected feeds → `filter.ts` → `sort.ts` → `paginateArray`. `types.ts` defines `queryOptsSchema` (zod), whose defaults (`defaultVisibleFeeds`, date-desc, 20/page) are what an empty query resolves to. `queryParams.ts` encodes/decodes that shape to/from URL search params via `qs` — note the `allowEmptyArrays` comment there; dropping it silently resurrects all feeds when the user deselects every source.
 
-### Env / secrets
+**Feeds are data; config supplies the types.** `feeds/feedManager.ts` exposes the hydrated, alphabetized `feeds` array plus `getFeedBySlug` / `isFeedSlug` / `defaultVisibleFeeds`. `feeds/feed.ts` hydration is what assigns each feed its canonical URLs (`/news/sources/{slug}`, `/feeds/{slug}/rss`, `/feeds/{slug}/atom`), so link to `feed.urls.*` rather than rebuilding paths.
 
-Server-only env vars are schema-validated in `astro.config.ts` (`env.schema`): `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN` (Redis cache), `CRON_SECRET` (protects the feed-update cron endpoint). Local values live in `.env` (gitignored).
+Re-publishing routes: `src/pages/feeds/[slug]/rss.ts` and `atom.ts` serve a single source's cached posts; `src/pages/feeds/all/opml.ts` emits an OPML list of all feeds.
 
-### Deployment
+### How the browse UI talks to the server
 
-Deployed to Vercel via `@astrojs/vercel` adapter (`maxDuration: 300` for the feed-update function). Sitemap generation (`@astrojs/sitemap`) uses a custom XSLT stylesheet at `public/xslt/sitemap.xslt`.
+Three entry points into `queryPosts`, all sharing `queryOptsSchema`:
+
+1. **Astro action** (`src/actions/index.ts`) — what the browse island uses for interactive re-queries.
+2. **REST** (`src/pages/api/posts.ts`) — public GET (query params) / POST (JSON body), documented on the `/developers` page.
+3. **Direct call** — SSR pages (`index.astro`, `news/stats`) call `queryPosts` server-side.
+
+`src/pages/news/browse/index.astro` decodes URL params server-side into `initialQuery`, then hands off to the `client:load` React island `_index.tsx`, which owns query state in `useState`. That island's effect has a deliberate stale-response guard (narrow queries resolve faster than broad ones, so an in-flight broad query can otherwise land last and clobber a narrow one); preserve it when editing.
+
+### Resources
+
+`src/lib/resources/config.ts` is a hand-maintained `Resource[]` (`url`, `title`, `description`). Inclusion criteria are in `README.md`: official Scouting America national-level publications only — no council/district/unit/third-party, not one item in a series, not a superseded version, not an individual document or form. Requests come in as GitHub issues (`.github/ISSUE_TEMPLATE/`).
+
+### Frontend conventions
+
+- Routes are `.astro` files under `src/pages/`. Files prefixed with `_` (e.g. `_index.tsx`, `_filterSidebar.tsx`) are **not routes** — they're that page's React island, colocated with it. Follow the convention for new page-specific components.
+- `Layout.astro` wraps `RootLayout.astro` + the `AppShell` island (sidebar chrome, command palette, dark mode); pages just supply `title` and children.
+- `src/components/ui/` is shadcn/ui — style `base-vega`, icons `lucide`, built on `@base-ui/react` (not Radix). Add components via the `shadcn` CLI so they match the configured style and aliases (`components.json`). Knip is configured to ignore unused exports in this directory.
+- Cross-page reusable islands live in `src/components/react/`; layout/sidebar pieces in `src/components/layout/`.
+- Tailwind v4 via `@tailwindcss/vite` — there is no `tailwind.config`; the theme lives in `src/global.css`. Fonts are declared in `astro.config.ts` via Astro font providers, not imported in CSS.
+- Path alias `@/*` → `src/*`. Imports are written as full `@/`-prefixed paths even within the same directory — match that.
+- Prettier uses **tabs**, with the tailwind class-sorting plugin.
+
+### Env / deployment
+
+Server env vars are schema-validated in `astro.config.ts` and imported from `astro:env/server`: `UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`, `CRON_SECRET`. Local values live in `.env` (gitignored). Deployed to Vercel via `@astrojs/vercel` (`maxDuration: 300` for the feed-update function). `trailingSlash: "never"`. Sitemap uses a custom XSLT at `public/xslt/sitemap.xslt`.
+
+Pages and routes that read Redis must set `export const prerender = false`.


### PR DESCRIPTION
Regenerates `CLAUDE.md` against the current codebase. The committed version had drifted:

- `src/lib/news/fetching/` → split into `ingest/` (adapters) and `posts/` (cache, fetch, update)
- `news/config.ts` → `news/feeds/config.ts`; `query/index.ts` → `query/query.ts`
- `resources/data.ts` → `resources/config.ts`, and resources no longer carry tags
- `FeedManager` class → plain `feeds` array + helpers in `feedManager.ts`
- `src/stores/postsQuery.ts` (nanostores) is gone — browse state is `useState` in the island
- shadcn style is `base-vega` on `@base-ui/react`, not `base-luma`
- pnpm is no longer enforced by a `preinstall` script

Also documents things that weren't covered before: the three entry points into `queryPosts` (Astro action, REST, direct SSR), the `_`-prefixed page-island convention, the stale-response guard in the browse effect, the `allowEmptyArrays` qs subtlety, and the `prerender = false` requirement for Redis-reading routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVc8o1VFikbaddLwZgwbDC